### PR TITLE
Tighten disposal handling and fix review links

### DIFF
--- a/src/iRLeagueManager.Web/Components/Dialogs/EditDialogBase.razor.cs
+++ b/src/iRLeagueManager.Web/Components/Dialogs/EditDialogBase.razor.cs
@@ -75,7 +75,7 @@ public class EditDialogBase<TViewModel, TModel> : MvvmComponentBase where TViewM
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing == false)
+        if (disposing)
         {
             Cts.Cancel();
             Cts.Dispose();

--- a/src/iRLeagueManager.Web/Pages/EditResult.razor
+++ b/src/iRLeagueManager.Web/Pages/EditResult.razor
@@ -84,7 +84,10 @@
 
     protected override void Dispose(bool disposing)
     {
-        Result.HasChanged -= OnResultChanged;
+        if (disposing)
+        {
+            Result.HasChanged -= OnResultChanged;
+        }
         base.Dispose(disposing);
     }
 

--- a/src/iRLeagueManager.Web/Pages/Reviews.razor
+++ b/src/iRLeagueManager.Web/Pages/Reviews.razor
@@ -350,7 +350,10 @@
 
     protected override void Dispose(bool disposing)
     {
-        NavigationManager.LocationChanged -= OnLocationChanged;
+        if (disposing)
+        {
+            NavigationManager.LocationChanged -= OnLocationChanged;
+        }
         base.Dispose(disposing);
     }
 
@@ -374,6 +377,6 @@
         {
             return GetCurrentSeasonLatestReviewLink();
         }
-        return $"{NavigationManager}{LeagueName}/Reviews/Events/{Event.EventId}";
+        return $"{NavigationManager.BaseUri}{LeagueName}/Reviews/Events/{Event.EventId}";
     }
 }

--- a/src/iRLeagueManager.Web/Pages/Settings/ChampionShipSettingsPage.razor
+++ b/src/iRLeagueManager.Web/Pages/Settings/ChampionShipSettingsPage.razor
@@ -249,4 +249,13 @@
     {
         InvokeAsync(StateHasChanged);
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            ChampSeason.HasChanged -= OnHasChanged;
+        }
+        base.Dispose(disposing);
+    }
 }

--- a/src/iRLeagueManager.Web/Pages/Standings.razor
+++ b/src/iRLeagueManager.Web/Pages/Standings.razor
@@ -144,7 +144,7 @@
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing == false)
+        if (disposing)
         {
             NavigationManager.LocationChanged -= OnLocationChanged;
         }

--- a/src/iRLeagueManager.Web/Shared/LeagueComponentBase.cs
+++ b/src/iRLeagueManager.Web/Shared/LeagueComponentBase.cs
@@ -142,7 +142,7 @@ public abstract partial class LeagueComponentBase : UtilityComponentBase
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing == false)
+        if (disposing)
         {
             EventList.PropertyChanged -= OnEventListPropertyChanged;
         }

--- a/src/iRLeagueManager.Web/Shared/UtilityComponentBase.cs
+++ b/src/iRLeagueManager.Web/Shared/UtilityComponentBase.cs
@@ -62,7 +62,7 @@ public class UtilityComponentBase : MvvmComponentBase
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing == false)
+        if (disposing)
         {
             locationChangingHandler?.Dispose();
             cancellationTokenSource.Cancel();

--- a/src/iRLeagueManager.Web/ViewModels/LeagueViewModelBase.cs
+++ b/src/iRLeagueManager.Web/ViewModels/LeagueViewModelBase.cs
@@ -111,13 +111,14 @@ public abstract class LeagueViewModelBase : ViewModelBase, IDisposable
     {
         if (!disposedValue)
         {
-            disposedValue = true;
-        }
+            if (disposing)
+            {
+                Cts.Cancel();
+                Cts.Dispose();
+                Loading = false;
+            }
 
-        if (!disposing)
-        {
-            Cts.Dispose();
-            Loading = false;
+            disposedValue = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- cancel outstanding requests when a league view model is disposed and release its loading state
- ensure UI components only detach handlers during managed disposal
- generate the correct absolute link for the current reviews page and release championship change listeners on dispose

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cd64097ecc8331b79374bb17bb1426